### PR TITLE
Add initial language system interface design

### DIFF
--- a/front-end/spiderchip/src/language-system/ls-interface-types.ts
+++ b/front-end/spiderchip/src/language-system/ls-interface-types.ts
@@ -1,5 +1,3 @@
-import * as PT from "./parser-types";
-
 export class Puzzle {
     slotCount: number; // number of varslots present
     defaultSlotNames: string[]; // default slot names to use, `slotCount` long, undefined if no name for that slot
@@ -50,7 +48,7 @@ export interface SpiderRuntime {
     /**
      * Obtain linter errors from parse result. Empty array if no errors.
      */
-    lint(): PT.ErrorMessage[];
+    lint(): SpiderError[];
 
     /**
      * Obtain the current state of the runtime environment.
@@ -68,6 +66,17 @@ export interface SpiderRuntime {
      */
     step(): undefined;
 }
+
+export class SpiderError {
+    line: number;
+    msg: string;
+
+    constructor(line: number, msg: string) {
+        this.line = line;
+        this.msg = msg;
+    }
+}
+
 
 export class SpiderState {
     state: SpiderStateEnum; // current parser state, see explanations of each on the enum


### PR DESCRIPTION
This would allow the frontend to start planning for using this system, even though it (obviously) isn't implemented yet.

The `Puzzle` object will need to be saved to the database (or otherwise able to be instantiated), but I don't yet have `PuzzleTest` designed so that might need to wait (since I'm still working on the LS itself).