### PR TITLE
Add language system

### DIFF
--- a/front-end/spiderchip/src/language-system/parser-types.ts
+++ b/front-end/spiderchip/src/language-system/parser-types.ts
@@ -218,9 +218,10 @@ export class ASTIf extends ASTNode {
 }
 
 export class ASTElse extends ASTNode {
+    iAmElse: boolean = true; // otherwise we're indistinguishable from the source
+
     constructor() {
         super();
-        // we don't need any data - our class alone is the indicator
     }
 }
 

--- a/front-end/spiderchip/src/language-system/parser.ts
+++ b/front-end/spiderchip/src/language-system/parser.ts
@@ -12,26 +12,26 @@ const RE_BRACKET_OPEN = /\[/;
 const RE_BRACKET_CLOSE = /\]/;
 const RE_PAREN_OPEN = /\(/;
 const RE_PAREN_CLOSE = /\)/;
-const RE_OPERATOR = /(>|>=|==|<=|<|&&|\|\||[*/%+-])/;
-const RE_UNARY_OPERATOR = /(-(?!\d)|!)/;
+const RE_OPERATOR = /(>|>=|==|!=|<=|<|&&|\|\||[*/%+-])/;
+const RE_UNARY_OPERATOR = /(-(?!\d)|!(?!=))/;
 const RE_NUMBER = /-?\d{1,3}/;
 const RE_IDENTIFIER = /[A-Za-z_][A-Za-z0-9_]*/;
 
 // ordered based on the binding strength from weakest to strongest
-const OPERATOR_BINDING_GROUPS = [["||"], ["&&"], [">", ">=", "==", "<=", "<"], ["+", "-"], ["*", "/", "%"]];
+const OPERATOR_BINDING_GROUPS = [["||"], ["&&"], [">", ">=", "==", "!=", "<=", "<"], ["+", "-"], ["*", "/", "%"]];
 
-const ObjectType = Object.freeze({
+const ObjectType = {
     CMD: "cmd",
     STACK: "stack",
     QUEUE: "queue"
-});
+};
 
 // function entries are name: argcount
-const SUPPORTED_OBJS = Object.freeze({
+const SUPPORTED_OBJS = {
     [ObjectType.CMD]: { next: 0 },
     [ObjectType.STACK]: { push: 1, pop: 0, length: 0 },
     [ObjectType.QUEUE]: { enqueue: 1, dequeue: 0, length: 0 }
-});
+};
 const SUPPORTED_FUNCS = { input: 0, output: 1, end: 0 };
 const RESERVED_KEYWORDS = ["if", "else", "while", "jump"];
 
@@ -619,6 +619,8 @@ function parseEquationAtomize(until: RegExp, parse: LineParse, result: PT.ParseR
         // optional unary operator
         // if we see this, we'll create a sub equation just for that argument to include the unary op
         // we disallow - followed by a number, so -999 is -999 not -1 * 999 (though that means - -999 is valid...)
+        // TODO: stacking unary operators is not yet supported, so something like !!x is impossible
+        //       it should be done using a chain of unary equation nodes, so no runtime changes necessary
         let unary: string | undefined = undefined;
         if (parse.match(RE_UNARY_OPERATOR)) {
             unary = parse.matched;


### PR DESCRIPTION
Had to make a couple of changes to the interface unfortunately:
- constructor for `Puzzle` has reordered arguments (!)
- constructor for `Puzzle` makes `defaultSlotNames` optional
- `SpiderState` contains some extra fields (`input` and `output`) - you shouldn't have been using this constructor anyway though

Below is some example code to use the language system:
```TypeScript
import * as LT from "./ls-interface-types";
import createRuntime from "./ls-system";

// initialize puzzle (this stuff should be pulled from database)
const objs = [];
const slots = null;
const tests = [
    new LT.PuzzleTest(objs, slots, [1,2,3], [1,2,3]),
    new LT.PuzzleTest(objs, slots, [1,2], [1,2])
];
const defaultNames = null;
const puzzle = new LT.Puzzle(5, tests, defaultNames, true, true);

// create the runtime
const rt = createRuntime(puzzle);

// create user code
const code = `x = input()
output(x)`;
// and user variables (ideally from some GUI element, I'm imagining typing onto the slot visualizer)
const customSlots = [new LT.CustomSlot(0, "x")];

// initialize runtime
rt.init(code, customSlots, 0);

// use runtime
let st = rt.state();
do {
    rt.step();
    st = rt.state();
    console.log(st.output); // or whatever you want to show while executing
} while (st.state === LT.SpiderStateEnum.RUNNING);
```